### PR TITLE
Added the fix for presence message to be sent

### DIFF
--- a/controller/modules/Signal.py
+++ b/controller/modules/Signal.py
@@ -455,9 +455,7 @@ class Signal(ControllerModule):
             for overlay_id in self._circles:
                 anc = self._circles[overlay_id]["Announce"]
                 if time.time() >= anc:
-                    self._circles[overlay_id]["Transport"].event_loop.call_soon_threadsafe(
-                        lambda: self._circles[overlay_id]["Transport"].send_presence(pstatus="ident#" +
-                                                                                             self.node_id))
+                    self._circles[overlay_id]["Transport"].send_presence(pstatus="ident#" + self.node_id)
                     self._circles[overlay_id]["Announce"] = time.time() + \
                         (int(self.config["PresenceInterval"]) * random.randint(2, 20))
                 self._circles[overlay_id]["JidCache"].scavenge()


### PR DESCRIPTION
Removed sending from the async method. Send presence is a synchronous method and can be called normally. There was a problem with calling it directly before but it is working fine now. I can see the presence "Resolved" messages after a while in the ctrl log.