### PR TITLE
Signal handling for SIGINT using sigaction

### DIFF
--- a/tincan/trunk/include/tincan.h
+++ b/tincan/trunk/include/tincan.h
@@ -22,6 +22,7 @@
 */
 #ifndef TINCAN_TINCAN_H_
 #define TINCAN_TINCAN_H_
+#include <signal.h>
 #include "tincan_base.h"
 #include "rtc_base/event.h"
 #include "control_listener.h"
@@ -76,7 +77,7 @@ public:
   void QueryLinkCas(
     const Json::Value & link_desc,
     Json::Value & cas_info) override;
-//
+
   void OnLocalCasUpdated(
     string link_id,
     string lcas);
@@ -96,6 +97,8 @@ private:
   static BOOL __stdcall ControlHandler(
     DWORD CtrlType);
 #endif // _TNC_WIN
+  //Signale handler for ctrl+C(SIGINT) linux
+  static void onStopHandler(int signum);
 
   vector<unique_ptr<BasicTunnel>> tunnels_;
   ControllerLink * ctrl_link_;

--- a/tincan/trunk/src/tincan.cc
+++ b/tincan/trunk/src/tincan.cc
@@ -302,6 +302,13 @@ Tincan::Run()
   self_ = this;
   SetConsoleCtrlHandler(ControlHandler, TRUE);
 #endif // _TNC_WIN
+  //Registering signal with signal handler
+  self_ = this;
+  struct sigaction newact, oldact;
+  newact.sa_handler = onStopHandler;
+  sigemptyset(&newact.sa_mask);
+  newact.sa_flags = 0;
+  sigaction(SIGINT, &newact, &oldact);
 
   //Start tincan control to get config from Controller
   unique_ptr<ControlDispatch> ctrl_dispatch(new ControlDispatch);
@@ -354,6 +361,13 @@ Tincan::Shutdown()
     tnl->Shutdown();
   }
   tunnels_.clear();
+}
+
+void
+Tincan::onStopHandler(int signum) {
+       cout << "Stopping tincan due to ctrl+c" << std::endl;
+       self_->OnStop();
+       exit(signum);
 }
 
 /*

--- a/tincan/trunk/src/tincan.cc
+++ b/tincan/trunk/src/tincan.cc
@@ -302,14 +302,17 @@ Tincan::Run()
   self_ = this;
   SetConsoleCtrlHandler(ControlHandler, TRUE);
 #endif // _TNC_WIN
+#if defined(_TNC_LINUX)
   //Registering signal with signal handler
   self_ = this;
-  struct sigaction newact, oldact;
+  struct sigaction newact;
+  memset(&newact, 0, sizeof(struct sigaction));
   newact.sa_handler = onStopHandler;
   sigemptyset(&newact.sa_mask);
   newact.sa_flags = 0;
-  sigaction(SIGINT, &newact, &oldact);
-
+  sigaction(SIGINT, &newact, NULL);
+  sigaction(SIGTERM, &newact, NULL);
+#endif
   //Start tincan control to get config from Controller
   unique_ptr<ControlDispatch> ctrl_dispatch(new ControlDispatch);
   ctrl_dispatch->SetDispatchToTincanInf(this);
@@ -363,12 +366,16 @@ Tincan::Shutdown()
   tunnels_.clear();
 }
 
+/*
+ * onStopHandler for handling SIGINT,SIGTERM in linux
+ * Calls OnStop() for shutdown of tincan
+ */
+#if defined(_TNC_LINUX)
 void
 Tincan::onStopHandler(int signum) {
-       cout << "Stopping tincan due to ctrl+c" << std::endl;
        self_->OnStop();
-       exit(signum);
 }
+#endif
 
 /*
 FUNCTION:ControlHandler


### PR DESCRIPTION
Testing:

/signalHandle/EdgeVPNio/evio/tincan/out/debian-x64/debug$ ./tincan
Control Listener now running
^CStopping tincan due to ctrl+c

--Need to test with docker Image.