### PR TITLE
[joss] Switch ACM 10.5555 DOIs to URLs

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -43,7 +43,7 @@
 @inproceedings{manku2003symphony,
 	location = {Berkeley, {CA}, {USA}},
 	title = {Symphony: Distributed Hashing in a Small World},
-	url = {http://dl.acm.org/citation.cfm?id=1251460.1251470},
+	url = {https://dl.acm.org/doi/10.5555/1251460.1251470},
 	series = {{USITS}'03},
 	shorttitle = {Symphony},
 	pages = {10--10},
@@ -52,7 +52,6 @@
 	author = {Manku, Gurmeet Singh and Bawa, Mayank and Raghavan, Prabhakar},
 	urldate = {2018-10-30},
 	date = {2003},
-	doi = {10.5555/1251460.1251470}
 }
 
 @article{openflow,
@@ -107,7 +106,7 @@ keywords = {ethernet switch, flow-based, virtualization}
   author={Zhang, Ben and Mor, Nitesh and Kolb, John and Chan, Douglas S and Lutz, Ken and Allman, Eric and Wawrzynek, John and Lee, Edward and Kubiatowicz, John},
   booktitle={7th USENIX Workshop on Hot Topics in Cloud Computing (HotCloud 15)},
   year={2015},
-  doi = {10.5555/2827719.2827740},
+  url = {https://dl.acm.org/doi/10.5555/2827719.2827740},
 }
 
 @misc{rfc5245,


### PR DESCRIPTION
Part of: https://github.com/openjournals/joss-reviews/issues/6638

Sorry for the double-PR here after https://github.com/EdgeVPNio/evio/pull/34

See also: https://github.com/openjournals/buffy/pull/106

ACM apparently does not actually register DOIs for many of its works, and what looks like a DOI actually isnt. So we have made a special case for checking 10.5555 prefixed "DOIs" that is OK with them in the URL field in the `https://dl.acm.org/doi` form

thanks for bearing with me on this, hopefully this is the last thing!